### PR TITLE
New version: CompactTranslatesDict v0.0.5

### DIFF
--- a/C/CompactTranslatesDict/Deps.toml
+++ b/C/CompactTranslatesDict/Deps.toml
@@ -8,9 +8,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ["0.0.0-0.0.2"]
 FrameFun = "bbafa164-4497-5d18-87cf-33e911f89480"
 
-["0.0.1-0.0.4"]
+["0.0.1-0.0.5"]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
-["0.0.4"]
+["0.0.4-0.0.5"]
 InfiniteVectors = "a3035606-0d97-52a5-9f37-19f5f67b7424"

--- a/C/CompactTranslatesDict/Versions.toml
+++ b/C/CompactTranslatesDict/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "7ae4add363484267043768b0b1c72262702b789c"
 
 ["0.0.4"]
 git-tree-sha1 = "bca6078d5327163bb30e16f1a1db3be4b9aefad0"
+
+["0.0.5"]
+git-tree-sha1 = "cf8a9070741d041f8b72e81c9e3ffd53be6b859c"


### PR DESCRIPTION
UUID: 455b6770-8cd4-11e8-0457-dd6f5558b097
Repo: https://github.com/vincentcp/CompactTranslatesDict.jl
Tree: cf8a9070741d041f8b72e81c9e3ffd53be6b859c