### PR TITLE
New version: CompactTranslatesDict v0.0.8

### DIFF
--- a/C/CompactTranslatesDict/Versions.toml
+++ b/C/CompactTranslatesDict/Versions.toml
@@ -20,4 +20,4 @@ git-tree-sha1 = "eb11006bd7eee35e7071a445a7d1ecbf13492535"
 git-tree-sha1 = "64a02f25f889d901025283d758736671d1209383"
 
 ["0.0.8"]
-git-tree-sha1 = "cf814b82b094d27f7aabba622fdd49bb34cadedc"
+git-tree-sha1 = "4042e5455eb5b52ac3a3d665c604332842cd6371"


### PR DESCRIPTION
UUID: 455b6770-8cd4-11e8-0457-dd6f5558b097
Repo: https://github.com/vincentcp/CompactTranslatesDict.jl
Tree: 4042e5455eb5b52ac3a3d665c604332842cd6371