### PR TITLE
New version: CompactTranslatesDict v0.1.2

### DIFF
--- a/C/CompactTranslatesDict/Compat.toml
+++ b/C/CompactTranslatesDict/Compat.toml
@@ -5,5 +5,8 @@ julia = "1"
 ["0.0.10-0.0"]
 BasisFunctions = "0.0"
 
-["0.1-0"]
+["0.1-0.1.1"]
 BasisFunctions = "0.1.1-*"
+
+["0.1.2-0"]
+BasisFunctions = "0.1.4-0.1"

--- a/C/CompactTranslatesDict/Deps.toml
+++ b/C/CompactTranslatesDict/Deps.toml
@@ -19,3 +19,6 @@ InfiniteVectors = "a3035606-0d97-52a5-9f37-19f5f67b7424"
 
 ["0.0.7-0"]
 GridArrays = "356ae075-8bc9-5ef9-a342-46c9ba26438c"
+
+["0.1.2-0"]
+DomainIntegrals = "cc6bae93-f070-4015-88fd-838f9505a86c"

--- a/C/CompactTranslatesDict/Versions.toml
+++ b/C/CompactTranslatesDict/Versions.toml
@@ -30,3 +30,6 @@ git-tree-sha1 = "c280a9accb37c06098be3cddc1d91394e69419ed"
 
 ["0.1.1"]
 git-tree-sha1 = "d3063e6372866863953d8459355e573a4f4393bf"
+
+["0.1.2"]
+git-tree-sha1 = "43e9f540e0a5780870069f29bc8b4aafd7423215"


### PR DESCRIPTION
UUID: 455b6770-8cd4-11e8-0457-dd6f5558b097
Repo: https://github.com/vincentcp/CompactTranslatesDict.jl
Tree: 43e9f540e0a5780870069f29bc8b4aafd7423215